### PR TITLE
Report port as closed if network is unreachable

### DIFF
--- a/lib/vagrant-chef-zero/server_helpers.rb
+++ b/lib/vagrant-chef-zero/server_helpers.rb
@@ -94,7 +94,7 @@ module VagrantPlugins
         begin
           TCPSocket.new(ip, port).close
           true
-        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH
           false
         end
       end


### PR DESCRIPTION
I'm running vagrant and vagrant-chef-zero on CentOS and when calling `vagrant destroy -f`I'm getting the following error:
```bash
==> w2008r2sql2008-std: Forcing shutdown of VM...
==> w2008r2sql2008-std: Destroying VM and associated drives...
/home/jenkins/.vagrant.d/gems/gems/vagrant-chef-zero-0.7.1/lib/vagrant-chef-zero/server_helpers.rb:95:in `initialize': Network is unreachable - connect(2) (Errno::ENETUNREACH)
	from /home/jenkins/.vagrant.d/gems/gems/vagrant-chef-zero-0.7.1/lib/vagrant-chef-zero/server_helpers.rb:95:in `new'
	from /home/jenkins/.vagrant.d/gems/gems/vagrant-chef-zero-0.7.1/lib/vagrant-chef-zero/server_helpers.rb:95:in `port_open?'
	from /home/jenkins/.vagrant.d/gems/gems/vagrant-chef-zero-0.7.1/lib/vagrant-chef-zero/server_helpers.rb:73:in `block in chef_zero_server_running?'
	from /opt/vagrant/embedded/lib/ruby/2.0.0/timeout.rb:66:in `timeout'
	from /home/jenkins/.vagrant.d/gems/gems/vagrant-chef-zero-0.7.1/lib/vagrant-chef-zero/server_helpers.rb:72:in `chef_zero_server_running?'
	from /home/jenkins/.vagrant.d/gems/gems/vagrant-chef-zero-0.7.1/lib/vagrant-chef-zero/server_helpers.rb:105:in `stop_chef_zero'
	from /home/jenkins/.vagrant.d/gems/gems/vagrant-chef-zero-0.7.1/lib/vagrant-chef-zero/action/stop.rb:19:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/providers/virtualbox/action/clean_machine_folder.rb:17:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/providers/virtualbox/action/destroy.rb:14:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/providers/virtualbox/action/forced_halt.rb:20:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/call.rb:53:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/call.rb:53:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/providers/virtualbox/action/discard_state.rb:15:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/providers/virtualbox/action/check_accessible.rb:18:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/call.rb:53:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/providers/virtualbox/action/check_virtualbox.rb:17:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/env_set.rb:19:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/providers/virtualbox/action/check_accessible.rb:18:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/call.rb:53:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/call.rb:53:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/providers/virtualbox/action/check_virtualbox.rb:17:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:196:in `action_raw'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:173:in `block in action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/environment.rb:474:in `lock'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:161:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:161:in `action'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/commands/destroy/command.rb:31:in `block in execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/plugin/v2/command.rb:226:in `block in with_target_vms'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/plugin/v2/command.rb:220:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/plugin/v2/command.rb:220:in `with_target_vms'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/commands/destroy/command.rb:30:in `execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/cli.rb:42:in `execute'
	from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/environment.rb:292:in `cli'
	from /opt/vagrant/bin/../embedded/gems/gems/vagrant-1.6.5/bin/vagrant:174:in `<main>'
```

This patch fixes that error.